### PR TITLE
fix spm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+.DS_Store
 
 ## Other
 *.moved-aside

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     targets: [
         .binaryTarget(
               name: "TalsecRuntime",
-              path: "TalsecRuntime.xcframework"
+              path: "Talsec/TalsecRuntime.xcframework"
         )
     ]
 )


### PR DESCRIPTION
I wasn't able to add TalsecRuntime to my project as spm dependency due to incorrect manifest placement. So I moved it to root directory